### PR TITLE
Reordered SSH key actions and enforces consistency on action labels

### DIFF
--- a/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ARCAD-AFS - Client - SSH Management
 Bundle-SymbolicName: com.arcadsoftware.afs.client.ssh;singleton:=true
-Bundle-Version: 2.2.0.qualifier
+Bundle-Version: 2.2.1.qualifier
 Bundle-Activator: com.arcadsoftware.afs.client.ssh.internal.Activator
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,

--- a/bundles/client/afs.client.ssh/nl/src/com/arcadsoftware/afs/client/ssh/resources.properties
+++ b/bundles/client/afs.client.ssh/nl/src/com/arcadsoftware/afs/client/ssh/resources.properties
@@ -1,25 +1,25 @@
 navigationView.node.sshkeys = SSH Keys
 
 sshkey.wizard.add.already.exists=A key named %s already exists. Please use another name.
-sshkey.action.add.text=Create a new key
-sshkey.action.add.tooltip=Create a new key
-sshkey.wizard.add.title=Create a new key
+sshkey.action.add.text=Create SSH key
+sshkey.action.add.tooltip=Generate a new SSH key
+sshkey.wizard.add.title=Generate a new key
 sshkey.wizard.add.page.main.text=General Properties
 sshkey.wizard.add.page.main.description=Define the new key properties.
 
-sshkey.action.import.text=Import an existing key
-sshkey.action.import.tooltip=Import an existing key
-sshkey.wizard.import.title=Import a key
+sshkey.action.import.text=Import SSH key
+sshkey.action.import.tooltip=Import an existing SSH key
+sshkey.wizard.import.title=Import an SSH key
 sshkey.wizard.import.page.main.text=General Properties
-sshkey.wizard.import.page.main.description=Select the key to import.
+sshkey.wizard.import.page.main.description=Select the SSH key to import.
 sshkey.wizard.import.server.error=A server error occurred while importing the private key:\n\n%1$s\n\nPlease check the server logs for more information
 sshkey.wizard.import.error=An error occurred while importing the private key:\n\n%1$s
 
-sshkey.action.delete.text=Delete
+sshkey.action.delete.text=Delete SSH key
 sshkey.action.delete.tooltip=Delete the selected SSH key(s)
 sshkey.action.delete.msg.confirm=Are you sure you want to delete the selected SSH key(s)?
 
-sshkey.action.edit.text=Edit
+sshkey.action.edit.text=Edit SSH key
 sshkey.action.edit.tooltip=Edit the selected SSH key(s)
 
 sshkey.action.open.public.key.text=Show public key
@@ -27,5 +27,5 @@ sshkey.action.open.public.key.tooltip=Open the selected key pair's public key
 sshkey.action.open.public.key.dialog.title=%1$s public key
 sshkey.action.open.public.key.dialog.description=You can copy and paste this public key into the remote authorized_keys file:
 
-sshkey.action.refresh.text=Refresh
-sshkey.action.refresh.tooltip=Refresh
+sshkey.action.refresh.text=Refresh SSH keys
+sshkey.action.refresh.tooltip=Refresh the SSH keys list

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/composites/SSHKeyListComposite.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/composites/SSHKeyListComposite.java
@@ -40,13 +40,8 @@ import com.arcadsoftware.metadata.MetaDataEntity;
 import com.arcadsoftware.ssh.model.SSHKey;
 
 public class SSHKeyListComposite extends AbstractSearchListComposite {
-
-	SSHKeyAddAction addAction;
-	SSHKeyDeleteAction deleteAction;
-	SSHKeyEditAction editAction;
-	SSHKeyImportAction importAction;
-	SSHKeyOpenPublicKeyAction openPublicKeyAction;
-	SSHKeyRefreshAction refreshAction;
+	private SSHKeyEditAction editAction;
+	private SSHKeyRefreshAction refreshAction;
 
 	public SSHKeyListComposite(final Composite parent, final MetaDataEntity entityStructure,
 			final ServerConnection connection) {
@@ -77,7 +72,7 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 	public List<Action> getActions() {
 		final List<Action> result = new ArrayList<>();
 
-		addAction = new SSHKeyAddAction(getConnection()) {
+		final SSHKeyAddAction addAction = new SSHKeyAddAction(getConnection()) {
 			@Override
 			protected void doAfterRun() {
 				refreshAction.run();
@@ -91,7 +86,7 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 			}
 		};
 
-		openPublicKeyAction = new SSHKeyOpenPublicKeyAction(getConnection()) {
+		final SSHKeyOpenPublicKeyAction openPublicKeyAction = new SSHKeyOpenPublicKeyAction(getConnection()) {
 			@Override
 			protected BeanMapList getBeanMapListToManage() {
 				return getSelectedBeanMap();
@@ -105,7 +100,7 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 			}
 		};
 
-		deleteAction = new SSHKeyDeleteAction(getConnection()) {
+		final SSHKeyDeleteAction deleteAction = new SSHKeyDeleteAction(getConnection()) {
 			@Override
 			protected void doAfterRun() {
 				refreshAction.run();
@@ -117,7 +112,7 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 			}
 		};
 
-		importAction = new SSHKeyImportAction(getConnection()) {
+		final SSHKeyImportAction importAction = new SSHKeyImportAction(getConnection()) {
 			@Override
 			protected void doAfterRun() {
 				refreshAction.run();
@@ -125,14 +120,14 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 		};
 
 		result.add(addAction);
-		result.add(importAction);
 		result.add(null);
 		result.add(editAction);
+		result.add(null);
+		result.add(importAction);
 		result.add(openPublicKeyAction);
+		result.add(refreshAction);
 		result.add(null);
 		result.add(deleteAction);
-		result.add(null);
-		result.add(refreshAction);
 
 		return result;
 	}


### PR DESCRIPTION
This PR reorders actions in the SSH keys view and enforce some consistency in their labels:
![image](https://github.com/ARCAD-Software/AFS/assets/11096890/9af80ca5-6232-4ac8-9dda-60c477cb121b)

This was done to meet the requirements for an internal issue opened with the Jira ID RDCODECHEC-510.