### PR TITLE
Removed default list actions in SSH keys view

### DIFF
--- a/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: AFS - Client SSH Management
 Bundle-SymbolicName: com.arcadsoftware.afs.client.ssh;singleton:=true
 Bundle-Vendor: ARCAD Software
-Bundle-Version: 2.2.1.qualifier
+Bundle-Version: 2.2.2.qualifier
 Bundle-Activator: com.arcadsoftware.afs.client.ssh.internal.Activator
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/composites/SSHKeyListComposite.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/composites/SSHKeyListComposite.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.osgi.framework.Bundle;
 
+import com.arcadsoftware.aev.core.ui.viewers.columned.AbstractColumnedViewer;
 import com.arcadsoftware.afs.client.brands.AFSIcon;
 import com.arcadsoftware.afs.client.core.connection.ServerConnection;
 import com.arcadsoftware.afs.client.core.ui.composites.AbstractSearchListComposite;
@@ -61,6 +62,13 @@ public class SSHKeyListComposite extends AbstractSearchListComposite {
 	@Override
 	protected String createSelectClause() {
 		return SSHKey.NAME + " " + SSHKey.TYPE + " " + SSHKey.LENGTH + " " + SSHKey.FINGERPRINT;
+	}
+
+	@Override
+	protected AbstractColumnedViewer createViewer(final Composite parent) {
+		final AbstractColumnedViewer abstractColumnedViewer = super.createViewer(parent);
+		abstractColumnedViewer.setHideDefaultActions(true);
+		return abstractColumnedViewer;
 	}
 
 	@Override

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/ui/views/SSHKeyListView.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/ui/views/SSHKeyListView.java
@@ -83,7 +83,7 @@ public class SSHKeyListView extends AbstractListView {
 	}
 
 	public void refreshKeys() {
-		if (isAllowedToSearch()) {
+		if (isAllowed()) {
 			sshKeyListComposite.search();
 		}
 	}

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/ui/views/SSHKeyListView.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/ui/views/SSHKeyListView.java
@@ -26,7 +26,6 @@ import com.arcadsoftware.afs.client.core.ui.views.AbstractListView;
 import com.arcadsoftware.afs.client.ssh.internal.ISSHRights;
 import com.arcadsoftware.afs.client.ssh.internal.RightManager;
 import com.arcadsoftware.afs.client.ssh.internal.composites.SSHKeyListComposite;
-import com.arcadsoftware.beanmap.BeanMap;
 import com.arcadsoftware.metadata.MetaDataEntity;
 import com.arcadsoftware.ssh.model.SSHKey;
 
@@ -34,16 +33,12 @@ public class SSHKeyListView extends AbstractListView {
 
 	public static final String ID = "com.arcadsoftware.afs.client.ssh.ui.views.SSHKeyListView"; //$NON-NLS-1$
 
-	BeanMap client = null;
-	SSHKeyListComposite listComposite;
-
-	public SSHKeyListView() {
-	}
+	private SSHKeyListComposite sshKeyListComposite;
 
 	@Override
 	protected AbstractSearchListComposite createListComposite(final Composite parent, final MetaDataEntity entity,
 			final ServerConnection connection) {
-		listComposite = new SSHKeyListComposite(parent, entity, connection) {
+		sshKeyListComposite = new SSHKeyListComposite(parent, entity, connection) {
 
 			@Override
 			protected String createOrderClause() {
@@ -56,13 +51,13 @@ public class SSHKeyListView extends AbstractListView {
 			}
 
 		};
-		return listComposite;
+		return sshKeyListComposite;
 	}
 
 	@Override
 	protected void fillToolbar(final IToolBarManager manager) {
 		super.fillToolbar(manager);
-		final List<Action> actions = listComposite.getActions();
+		final List<Action> actions = sshKeyListComposite.getActions();
 		for (final Action action : actions) {
 			if (action != null) {
 				manager.add(action);
@@ -84,12 +79,12 @@ public class SSHKeyListView extends AbstractListView {
 
 	@Override
 	protected void readStructureError() {
-
+		// Nothing to do here
 	}
 
 	public void refreshKeys() {
 		if (isAllowedToSearch()) {
-			listComposite.search();
+			sshKeyListComposite.search();
 		}
 	}
 


### PR DESCRIPTION
The right-click menu in the SSH keys list contained unused action inherited from AEV.
This PR removes these actions.