### PR TITLE
Fix import constraints for RAP 3.6

### DIFF
--- a/bundles/client/afs.client.brands/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.client.brands/META-INF/MANIFEST.MF
@@ -2,12 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AFS - Branding Bundle
 Bundle-SymbolicName: com.arcadsoftware.afs.client.brands;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.3.qualifier
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.jface;bundle-version="[3.10.0,4.0.0)",
- org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)"
+Require-Bundle: org.eclipse.jface;bundle-version="[3.10.0,4.0.0)";resolution:=optional,
+ org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)",
+ org.eclipse.rap.jface;bundle-version="[3.6.0,4.0.0)";resolution:=optional
 Bundle-ClassPath: .
 Bundle-Vendor: ARCAD Software
 Automatic-Module-Name: com.arcadsoftware.afs.client.brands

--- a/bundles/client/afs.client.editors/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.client.editors/META-INF/MANIFEST.MF
@@ -2,17 +2,17 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AFS - Client Dynamic Editors
 Bundle-SymbolicName: com.arcadsoftware.afs.client.editors;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.3.qualifier
 Bundle-Vendor: ARCAD Software
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.databinding;bundle-version="[1.1.0,2.0.0)";visibility:=reexport,
  org.eclipse.jface.databinding;bundle-version="[1.2.0,2.0.0)";resolution:=optional;visibility:=reexport,
- org.eclipse.rap.jface.databinding;bundle-version="[1.4.0,3.0.0)";resolution:=optional,
+ org.eclipse.rap.jface.databinding;bundle-version="[3.6.0,4.0.0)";resolution:=optional,
  org.eclipse.ui;resolution:=optional,
- org.eclipse.rap.ui;bundle-version="[1.4.0,3.0.0)";resolution:=optional,
+ org.eclipse.rap.ui;bundle-version="[3.6.0,4.0.0)";resolution:=optional,
  org.eclipse.ui.forms;bundle-version="[3.6.0,4.0.0)";resolution:=optional;visibility:=reexport,
- org.eclipse.rap.ui.forms;bundle-version="[1.4.0,3.0.0)";resolution:=optional,
+ org.eclipse.rap.ui.forms;bundle-version="[3.6.0,4.0.0)";resolution:=optional,
  com.arcadsoftware.osgi;bundle-version="[1.8.0,2.0.0)",
  com.arcadsoftware.metadata;bundle-version="[1.5.0,2.0.0)",
  com.arcadsoftware.aev.core;bundle-version="[12.0.0,13.0.0)",

--- a/bundles/client/afs.framework.application/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.framework.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AFS - Framework Application
 Bundle-SymbolicName: com.arcadsoftware.afs.framework.application;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.4.qualifier
 Bundle-Activator: com.arcadsoftware.afs.framework.application.internal.Activator
 Bundle-Vendor: ARCAD Software
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -12,8 +12,8 @@ Export-Package: com.arcadsoftware.afs.framework.application;version="1.0.0",
  com.arcadsoftware.afs.framework.application.action;version="1.0.0"
 Require-Bundle: org.eclipse.ui;bundle-version="[3.4.2,4.0.0)";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.rap.ui;bundle-version="[2.1.0,3.0.0)";resolution:=optional,
- org.eclipse.rap.ui.workbench;bundle-version="[2.1.0,3.0.0)";resolution:=optional
+ org.eclipse.rap.ui;bundle-version="[3.6.0,4.0.0)";resolution:=optional,
+ org.eclipse.rap.ui.workbench;bundle-version="[3.6.0,4.0.0)";resolution:=optional
 Automatic-Module-Name: com.arcadsoftware.afs.framework.application
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Bundle-License-Name: Eclipse Public License Version 2.0


### PR DESCRIPTION
Some bundle manifests needed to be updated to allow them to run with RAP 3.6