### PR TITLE
Fix EdDSA SSH key generation on IBM i

### DIFF
--- a/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
+++ b/bundles/client/afs.client.ssh/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: AFS - Client SSH Management
 Bundle-SymbolicName: com.arcadsoftware.afs.client.ssh;singleton:=true
 Bundle-Vendor: ARCAD Software
-Bundle-Version: 2.2.5.qualifier
+Bundle-Version: 2.2.6.qualifier
 Bundle-Activator: com.arcadsoftware.afs.client.ssh.internal.Activator
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyAddAction.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyAddAction.java
@@ -61,7 +61,7 @@ public class SSHKeyAddAction extends AbstractConnectedWizardedAddAction {
 
 	@Override
 	public UserMessage getErrorMessage() {
-		return null;
+		return helper.getLastMessage();
 	}
 
 	@Override
@@ -110,9 +110,14 @@ public class SSHKeyAddAction extends AbstractConnectedWizardedAddAction {
 		}
 
 		if (sshKey.isEncrypted()) {
-			sshKey.setPassphrase(Crypto.fog(sshKey.getPassphrase().toCharArray(), StandardCharsets.UTF_8));
+			sshKey.setPassphrase(Crypto.fog(sshKey.getPassphrase(), StandardCharsets.UTF_8));
 		}
-		return helper.put(SSHRoutes.GENERATE_KEY, sshKey.getBeanMap());
+		final boolean result = helper.put(SSHRoutes.GENERATE_KEY, sshKey.getBeanMap());
+		if(!result) {
+			MessageDialog.openError(Activator.getDefault().getPluginShell(),
+					"ARCAD Software", helper.getLastMessage().toString());
+		}
+		return result;
 	}
 
 	@Override

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyImportAction.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyImportAction.java
@@ -119,7 +119,7 @@ public class SSHKeyImportAction extends AbstractConnectedWizardedAddAction {
 			keyUpload.setPrivateKey(privateKey);	
 			final String s = keyUpload.getPassphrase();
 			if((s != null) && !s.isEmpty()) {
-				keyUpload.setPassphrase(Crypto.fog(s.toCharArray(), StandardCharsets.UTF_8));				
+				keyUpload.setPassphrase(Crypto.fog(s, StandardCharsets.UTF_8));				
 			}
 			final BeanMap uploadResult = helper.getConnection().getDataAccess().post(SSHRoutes.IMPORT_KEY, keyUpload.getBeanmap());
 			if (uploadResult == null) {

--- a/bundles/common/ssh/META-INF/MANIFEST.MF
+++ b/bundles/common/ssh/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AFS SSH Connections Management
 Bundle-SymbolicName: com.arcadsoftware.ssh
-Bundle-Version: 1.2.4.qualifier
+Bundle-Version: 1.2.5.qualifier
 Bundle-Vendor: ARCAD Software
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.arcadsoftware.ssh.model;version="1.0.0"

--- a/bundles/common/ssh/src/com/arcadsoftware/ssh/model/SSHKeyType.java
+++ b/bundles/common/ssh/src/com/arcadsoftware/ssh/model/SSHKeyType.java
@@ -15,9 +15,9 @@ package com.arcadsoftware.ssh.model;
 
 public enum SSHKeyType {
 	
-	UNKNOWN("", 0, "", ""), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	RSA("RSA", 4096, "id_rsa", "id_rsa.pub"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	EDDSA("EdDSA", 0, "id_ed25519", "id_ed25519.pub"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	UNKNOWN("", 0, "", "", ""), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	RSA("RSA", 4096, "id_rsa", "id_rsa.pub", "BC"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	EDDSA("EdDSA", 0, "id_ed25519", "id_ed25519.pub", "EdDSA"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	public static SSHKeyType fromAlgorithm(final String algo) {
 		if ((algo != null) && ! algo.isEmpty()) {
@@ -34,12 +34,14 @@ public enum SSHKeyType {
 	private final int length;
 	private final String privateKeyName;
 	private final String publicKeyName;
+	private final String provider;
 
-	SSHKeyType(final String algorithm, final int length, final String privateKeyName, final String publicKeyName) {
+	SSHKeyType(final String algorithm, final int length, final String privateKeyName, final String publicKeyName, final String provider) {
 		this.algorithm = algorithm;
 		this.length = length;
 		this.privateKeyName = privateKeyName;
 		this.publicKeyName = publicKeyName;
+		this.provider = provider;
 	}
 
 	public String getAlgorithm() {
@@ -56,5 +58,9 @@ public enum SSHKeyType {
 
 	public String getPublicKeyName() {
 		return publicKeyName;
+	}
+	
+	public String getProvider() {
+		return provider;
 	}
 }

--- a/bundles/server/server.ssh/META-INF/MANIFEST.MF
+++ b/bundles/server/server.ssh/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SSH Connection Management
 Bundle-SymbolicName: com.arcadsoftware.server.ssh
-Bundle-Version: 2.3.3.qualifier
+Bundle-Version: 2.3.4.qualifier
 Bundle-Vendor: ARCAD Software
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.arcadsoftware.beanmap;version="[2.1.0,3.0.0)",

--- a/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/internal/resources/SSHGenerateKeyResource.java
+++ b/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/internal/resources/SSHGenerateKeyResource.java
@@ -64,7 +64,7 @@ public class SSHGenerateKeyResource extends BeanMapItemResource {
 			bean.addAll(sshKey.getBeanMap());
 			bean.forceId(sshKey.getId());
 		} catch (final SSHException e) {
-			throw new ResourceException(Status.CLIENT_ERROR_BAD_REQUEST, e);
+			throw new ResourceException(Status.SERVER_ERROR_INTERNAL, e.getMessage(), e);
 		}
 	}
 }

--- a/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/services/SSHService.java
+++ b/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/services/SSHService.java
@@ -59,7 +59,7 @@ public class SSHService {
 
 	private static final String PRIVATE_KEY_FILE = "private_key";
 	private static final String KEYSTORE_DIRECTORY = "./ssh/keystore";
-	private static final HashSet<PosixFilePermission> CHMOD_600 = new HashSet<PosixFilePermission>(2);
+	private static final HashSet<PosixFilePermission> CHMOD_600 = new HashSet<>(2);
 	
 	static {
 		CHMOD_600.add(PosixFilePermission.OWNER_READ);
@@ -121,7 +121,7 @@ public class SSHService {
 			generateKeyPair(newSSHKey);
 		} catch (IOException | GeneralSecurityException e) {
 			delete(newSSHKey);
-			throw new SSHException("Error occurred while creation new SSH key", e);
+			throw new SSHException("Error occurred while creating new SSH key: " + e, e);
 		}
 		return newSSHKey;
 	}

--- a/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/services/SSHService.java
+++ b/bundles/server/server.ssh/src/com/arcadsoftware/server/ssh/services/SSHService.java
@@ -153,7 +153,7 @@ public class SSHService {
 
 	private void generateKeyPair(final SSHKey sshKey) throws IOException, GeneralSecurityException {
 		final SSHKeyType keyType = sshKey.getType();
-		final KeyPairGenerator generator = KeyPairGenerator.getInstance(keyType.getAlgorithm());
+		final KeyPairGenerator generator = KeyPairGenerator.getInstance(keyType.getAlgorithm(), keyType.getProvider());
 		if (sshKey.getLength() > 0) {
 			generator.initialize(sshKey.getLength());
 		}


### PR DESCRIPTION
This PR fixes the EdDSA SSH key generation on IBM i, that crashes on IBM i 7.4 and above.

Not specifying a provider name when invoking `KeyPairGenerator::getInstance` results in IBM's provider to be used by default on IBM i instead of net.i2p's. The generation then crashes because it can't recognize the key type since IBM's implementation doesn't return the expected key type.

The following providers are now explicitly provided to `KeyPairGenerator::getInstance`:
- `BC` when generating an `RSA` key
- `EdDSA` when generating an `EdDSA` key