### PR TITLE
Add UI warnings about EdDSA suspended support

### DIFF
--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyAddAction.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyAddAction.java
@@ -101,14 +101,8 @@ public class SSHKeyAddAction extends AbstractConnectedWizardedAddAction {
 
 	@Override
 	public boolean saveBeanMap(final BeanMap beanMap) {
-		final SSHKey sshKey = new SSHKey(beanMap);
-
-		if (sshKey.getAlgorithm().equals("1")) {
-			sshKey.setType(SSHKeyType.RSA);
-		} else {
-			sshKey.setType(SSHKeyType.EDDSA);
-		}
-
+		final SSHKey sshKey = new SSHKey(beanMap);		
+		sshKey.setType(SSHKeyType.RSA);
 		if (sshKey.isEncrypted()) {
 			sshKey.setPassphrase(Crypto.fog(sshKey.getPassphrase(), StandardCharsets.UTF_8));
 		}

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyOpenPublicKeyAction.java
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/internal/actions/SSHKeyOpenPublicKeyAction.java
@@ -25,6 +25,7 @@ import com.arcadsoftware.afs.client.ssh.ui.dialogs.SSHPublicKeyDialog;
 import com.arcadsoftware.beanmap.BeanMap;
 import com.arcadsoftware.beanmap.BeanMapList;
 import com.arcadsoftware.ssh.model.SSHKey;
+import com.arcadsoftware.ssh.model.SSHKeyType;
 
 public class SSHKeyOpenPublicKeyAction extends AbstractConnectedBeanMapAction {
 
@@ -53,8 +54,14 @@ public class SSHKeyOpenPublicKeyAction extends AbstractConnectedBeanMapAction {
 		return RightManager.getInstance().getExpectedRights(ISSHRights.SSHKEY_EDIT);
 	}
 
-	public void openPublicKey(final BeanMap key) {
-		new SSHPublicKeyDialog(connection, new SSHKey(key)).open();
+	public void openPublicKey(final BeanMap bean) {
+		final SSHKey key = new SSHKey(bean);
+		if(key.getType() == SSHKeyType.EDDSA) {
+			Activator.getDefault().openWarning(Activator.resString("sshkey.eddsa.support.suspended"));
+		}
+		else {
+			new SSHPublicKeyDialog(connection, key).open();
+		}
 	}
 
 	@Override

--- a/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/resources.properties
+++ b/bundles/client/afs.client.ssh/src/com/arcadsoftware/afs/client/ssh/resources.properties
@@ -29,3 +29,5 @@ sshkey.action.open.public.key.dialog.description=You can copy and paste this pub
 
 sshkey.action.refresh.text=Refresh SSH keys
 sshkey.action.refresh.tooltip=Refresh the SSH keys list
+
+sshkey.eddsa.support.suspended=To fix CVE-2020-36843, EdDSA key type support has been suspended.\nIt will be back in a future release supporting Java 17.

--- a/bundles/server/server.ssh/OSGI-INF/com.arcadsoftware.server.ssh.services.SSHService.xml
+++ b/bundles/server/server.ssh/OSGI-INF/com.arcadsoftware.server.ssh.services.SSHService.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="com.arcadsoftware.server.ssh.services.SSHService">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="com.arcadsoftware.server.ssh.services.SSHService">
    <service>
       <provide interface="com.arcadsoftware.server.ssh.services.SSHService"/>
    </service>

--- a/bundles/server/server.ssh/files/layouts/sshKey/main_page.xml
+++ b/bundles/server/server.ssh/files/layouts/sshKey/main_page.xml
@@ -4,12 +4,6 @@
 	<param id="background-color-swt" value="22" />
 	<composite fillBoth="true" withMargin="true" border="false">
 		<input attribute="name" mandatory="true" />
-		<comboFixedValue attribute="keytype" readOnly="true">
-			<!-- Support for EdDSA suspended until we move to Java 17
-			<item index="0" value="EdDSA" />
-			 -->
-			<item index="0" value="RSA" />			
-		</comboFixedValue>
 		<input attribute="passphrase" isPassword="true" />
 		<input attribute="keycomment" />
 	</composite>

--- a/bundles/server/server.ssh/files/layouts/sshKey/main_page.xml
+++ b/bundles/server/server.ssh/files/layouts/sshKey/main_page.xml
@@ -5,8 +5,10 @@
 	<composite fillBoth="true" withMargin="true" border="false">
 		<input attribute="name" mandatory="true" />
 		<comboFixedValue attribute="keytype" readOnly="true">
+			<!-- Support for EdDSA suspended until we move to Java 17
 			<item index="0" value="EdDSA" />
-			<item index="1" value="RSA" />			
+			 -->
+			<item index="0" value="RSA" />			
 		</comboFixedValue>
 		<input attribute="passphrase" isPassword="true" />
 		<input attribute="keycomment" />


### PR DESCRIPTION
This PR adds a warning when a user tries to display an EdDSA public key.
![image](https://github.com/user-attachments/assets/9e057b93-37e9-4010-b673-cfcc523f0ed9)

It also removes the key type selection when creating a new key.